### PR TITLE
Watch only directories containing target files

### DIFF
--- a/goemon.go
+++ b/goemon.go
@@ -188,12 +188,18 @@ func (g *goemon) watch() error {
 		if info == nil {
 			return err
 		}
-		if !info.IsDir() {
+		if info.IsDir() {
 			return nil
 		}
-		if _, ok := dup[path]; !ok {
-			g.fsw.Add(path)
-			dup[path] = true
+		dir := filepath.Dir(path)
+		if _, ok := dup[dir]; !ok {
+			for _, t := range g.conf.Tasks {
+				if t.match(path) {
+					g.fsw.Add(dir)
+					dup[dir] = true
+					break
+				}
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
Currently, goemon watches all directories under the current directory. 

https://github.com/mattn/goemon/blob/f52196b35317037f6e8e2d30d75fc7f7ee74c707/goemon.go#L187

In Mac, fsnotify.Add opens all files under the directory, which is likely to cause "too many open files" error.

This PR checks whether a directory contains a file which matches the pattern specified by the user before adding to fsnotify.

here are my `go veresion` and `go env`.

```
❯ go version
go version go1.7.3 darwin/amd64
❯ go env
GOARCH="amd64"
GOBIN=""
GOEXE=""
GOHOSTARCH="amd64"
GOHOSTOS="darwin"
GOOS="darwin"
GOPATH="/Users/okuno/.go"
GORACE=""
GOROOT="/usr/local/opt/go/libexec"
GOTOOLDIR="/usr/local/opt/go/libexec/pkg/tool/darwin_amd64"
CC="clang"
GOGCCFLAGS="-fPIC -m64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/var/folders/t9/_rzzzbgs7nb2sclqh1f2flr40000gn/T/go-build061422342=/tmp/go-build -gno-record-gcc-switches -fno-common"
CXX="clang++"
CGO_ENABLED="1"
```
