### PR TITLE
Fix wait condition after sending signal in terminate

### DIFF
--- a/proc_posix.go
+++ b/proc_posix.go
@@ -22,14 +22,14 @@ func (g *goemon) terminate() error {
 		} else {
 			cd := 5
 			for cd > 0 {
-				if g.cmd.ProcessState != nil && g.cmd.ProcessState.Exited() {
+				if g.cmd.ProcessState != nil {
 					break
 				}
 				time.Sleep(time.Second)
 				cd--
 			}
 		}
-		if g.cmd.ProcessState != nil && g.cmd.ProcessState.Exited() {
+		if g.cmd.ProcessState == nil {
 			g.cmd.Process.Kill()
 		}
 	}


### PR DESCRIPTION
日本語で失礼します

## 起きてること

 goemon.terminate() を呼ぶと必ず 5 秒間待ってしまう（windows では確認出来ていません）
```cmd.Process.Signal``` を送り cmd が終了した場合 ```ProcessState.Exited()``` は false を返すこことが原因のようです。

下のログはどちらも起動直後に ctrl-c を送ったものです。

### before

```
 goemon git:(master) time goemon sleep 10
GOEMON 2017/01/26 13:47:19 goemon.go:273: open /Users/soh335/dev/src/github.com/mattn/goemon/goemon.yml: no such file or directory
GOEMON 2017/01/26 13:47:19 goemon.go:306: starting command [sleep 10]
GOEMON 2017/01/26 13:47:19 goemon.go:277: loading /Users/soh335/dev/src/github.com/mattn/goemon/goemon.yml
GOEMON 2017/01/26 13:47:19 goemon.go:294: starting livereload
GOEMON 2017/01/26 13:47:19 goemon.go:210: goemon loaded /Users/soh335/dev/src/github.com/mattn/goemon/goemon.yml
^Cgoemon sleep 10  0.02s user 0.04s system 1% cpu 5.684 total
```

### after

```
 goemon git:(fix/terminate) time goemon sleep 10
GOEMON 2017/01/26 13:47:35 goemon.go:273: open /Users/soh335/dev/src/github.com/mattn/goemon/goemon.yml: no such file or directory
GOEMON 2017/01/26 13:47:35 goemon.go:306: starting command [sleep 10]
GOEMON 2017/01/26 13:47:35 goemon.go:277: loading /Users/soh335/dev/src/github.com/mattn/goemon/goemon.yml
GOEMON 2017/01/26 13:47:35 goemon.go:294: starting livereload
GOEMON 2017/01/26 13:47:35 goemon.go:210: goemon loaded /Users/soh335/dev/src/github.com/mattn/goemon/goemon.yml
^Cgoemon sleep 10  0.02s user 0.02s system 2% cpu 1.703 total
```

何か勘違いしてたらすいません！

## 環境

```
$ go version
go version go1.7.4 darwin/amd64
```