### PR TITLE
Execute commands with tty

### DIFF
--- a/command.go
+++ b/command.go
@@ -99,6 +99,7 @@ func (g *goemon) externalCommand(command, file string) bool {
 		cmd = exec.Command("sh", "-c", command)
 	}
 	g.Logger.Println("executing", command)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()


### PR DESCRIPTION
Some commands require tty.
e.g. azure-cli

And sphinx with latex, can't add latex parameters (-quiet, -interaction=batchmode), therefore suddenly stop running by latex's prompt and never proceeding it.

This pull-request add `:tty` internal command, useful for above cases.

```
---
tasks:
- match: './**/*.rst'
  commands:
  - :tty mingw32-make latex
```