### PR TITLE
Fix import path for fsnotify

### DIFF
--- a/command.go
+++ b/command.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/omeid/jsmin"
 	"github.com/omeid/livereload"
 	"github.com/tdewolff/minify"
 	"github.com/tdewolff/minify/css"
-	"gopkg.in/fsnotify.v1"
 )
 
 func (g *goemon) internalCommand(command, file string) bool {

--- a/goemon.go
+++ b/goemon.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/omeid/livereload"
-	"gopkg.in/fsnotify.v1"
 	"gopkg.in/yaml.v2"
 )
 


### PR DESCRIPTION
`go get` すると下記エラーとなりました。
```
package gopkg.in/fsnotify.v1: unrecognized import path "gopkg.in/fsnotify.v1"
 (parse https://gopkg.in/fsnotify.v1?go-get=1: no go-import meta tags 
(meta tag gopkg.in/fsnotify/fsnotify.v1 did not match import path gopkg.in/fsnotify.v1))
```

`fsnotify` の `import path` が変更されているようです。

https://github.com/fsnotify/fsnotify/issues/108

ご検討下さい