### PR TITLE
fix posix kill

### DIFF
--- a/proc_posix.go
+++ b/proc_posix.go
@@ -32,7 +32,7 @@ func (g *goemon) terminate(sig os.Signal) error {
 			}
 			time.Sleep(100)
 		}
-		return kill(g.cmd.Process)
+		return g.cmd.Process.Kill()
 	}
 	return nil
 }


### PR DESCRIPTION
A `kill` function exists only in windows. 